### PR TITLE
Add dynamic footer year

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
     </section>
 
     <footer>
-        <p>&copy; 2025 Terrassa Metal Fest. Todos los derechos reservados.</p>
+        <p>&copy; <span id="currentYear"></span> Terrassa Metal Fest. Todos los derechos reservados.</p>
     </footer>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -66,5 +66,16 @@ function createBandCards() {
     });
 }
 
-// Crear las tarjetas de las bandas cuando el DOM esté listo
-document.addEventListener('DOMContentLoaded', createBandCards);
+// Establecer el año actual en el footer
+function setFooterYear() {
+    const yearElement = document.getElementById('currentYear');
+    if (yearElement) {
+        yearElement.textContent = new Date().getFullYear();
+    }
+}
+
+// Ejecutar funciones cuando el DOM esté listo
+document.addEventListener('DOMContentLoaded', () => {
+    createBandCards();
+    setFooterYear();
+});


### PR DESCRIPTION
## Summary
- show current year in the footer
- insert setFooterYear function and run it on DOM load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684a011b84188331a305b88dff1ed5a4