### PR TITLE
Actualizar lineup y fondo

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,11 +64,6 @@
         </div>
     </section>
 
-    <section id="poster" class="poster fade-in">
-        <div style="text-align: center;">
-            <img src="cartel diseño instagram  final.png" alt="Cartel Terrassa Metal Fest 2025" style="max-width:100%; height:auto;">
-        </div>
-    </section>
 
     <section id="lineup" class="lineup fade-in">
         <h2>Lineup</h2>

--- a/script.js
+++ b/script.js
@@ -32,21 +32,22 @@ const countdownInterval = setInterval(updateCountdown, 1000);
 updateCountdown();
 
 // Ejemplo de bandas (estos datos deberían actualizarse según el lineup real)
+const posterPath = 'cartel diseño instagram  final.png';
 const bands = [
     {
-        name: "TBD",
+        name: `<img src="${posterPath}" alt="Cartel pequeño" class="small-poster">`,
         image: "https://via.placeholder.com/300x300",
-        description: "Próximamente"
+        description: "2025"
     },
     {
-        name: "TBD",
+        name: `<img src="${posterPath}" alt="Cartel pequeño" class="small-poster">`,
         image: "https://via.placeholder.com/300x300",
-        description: "Próximamente"
+        description: "2025"
     },
     {
-        name: "TBD",
+        name: `<img src="${posterPath}" alt="Cartel pequeño" class="small-poster">`,
         image: "https://via.placeholder.com/300x300",
-        description: "Próximamente"
+        description: "2025"
     }
 ];
 

--- a/style.css
+++ b/style.css
@@ -62,8 +62,7 @@ body {
 /* Hero Section */
 .hero {
     height: 100vh;
-    background: linear-gradient(rgba(139, 0, 0, 0.8), rgba(0, 0, 0, 0.8)),
-                url('png negro logo.png');
+    background: linear-gradient(rgba(139, 0, 0, 0.8), rgba(0, 0, 0, 0.8));
     background-size: cover;
     background-position: center;
     display: flex;
@@ -135,6 +134,12 @@ body {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 2rem;
+}
+
+/* Small poster used in lineup placeholders */
+.small-poster {
+    width: 80px;
+    height: auto;
 }
 
 /* Info Section */


### PR DESCRIPTION
## Summary
- quitar imagen de fondo "png negro logo.png" para la seccion hero
- eliminar seccion del cartel grande
- usar una version pequeña del cartel en las tarjetas de lineup y cambiar el texto a "2025"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852a73768248331bca53b1b221c2f15