### PR TITLE
Actualizar lineup

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,11 +64,6 @@
         </div>
     </section>
 
-    <section id="poster" class="poster fade-in">
-        <div style="text-align: center;">
-            <img src="cartel diseño instagram  final.png" alt="Cartel Terrassa Metal Fest 2025" style="max-width:100%; height:auto;">
-        </div>
-    </section>
 
     <section id="lineup" class="lineup fade-in">
         <h2>Lineup</h2>

--- a/script.js
+++ b/script.js
@@ -32,21 +32,25 @@ const countdownInterval = setInterval(updateCountdown, 1000);
 updateCountdown();
 
 // Ejemplo de bandas (estos datos deberían actualizarse según el lineup real)
+const posterPath = 'cartel diseño instagram  final.png';
 const bands = [
     {
-        name: "TBD",
-        image: "https://via.placeholder.com/300x300",
-        description: "Próximamente"
+        name: "Cartel",
+        alt: "Cartel",
+        image: posterPath,
+        description: "2025"
     },
     {
         name: "TBD",
+        alt: "Banda por anunciar",
         image: "https://via.placeholder.com/300x300",
-        description: "Próximamente"
+        description: "2025"
     },
     {
         name: "TBD",
+        alt: "Banda por anunciar",
         image: "https://via.placeholder.com/300x300",
-        description: "Próximamente"
+        description: "2025"
     }
 ];
 
@@ -54,11 +58,12 @@ const bands = [
 function createBandCards() {
     const lineupContainer = document.querySelector('.lineup-container');
     
-    bands.forEach(band => {
+    bands.forEach((band, index) => {
         const bandCard = document.createElement('div');
         bandCard.className = 'band-card';
+        const imgClass = index === 0 ? ' class="small-poster"' : '';
         bandCard.innerHTML = `
-            <img src="${band.image}" alt="${band.name}">
+            <img src="${band.image}" alt="${band.alt}"${imgClass}>
             <h3>${band.name}</h3>
             <p>${band.description}</p>
         `;

--- a/style.css
+++ b/style.css
@@ -62,8 +62,7 @@ body {
 /* Hero Section */
 .hero {
     height: 100vh;
-    background: linear-gradient(rgba(139, 0, 0, 0.8), rgba(0, 0, 0, 0.8)),
-                url('png negro logo.png');
+    background: linear-gradient(rgba(139, 0, 0, 0.8), rgba(0, 0, 0, 0.8));
     background-size: cover;
     background-position: center;
     display: flex;
@@ -135,6 +134,12 @@ body {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 2rem;
+}
+
+/* Small poster used in lineup placeholders */
+.small-poster {
+    width: 80px;
+    height: auto;
 }
 
 /* Info Section */


### PR DESCRIPTION
## Summary
- mantener el cartel pequeño solo en la primera tarjeta del lineup
- cambiar el texto alternativo al cartel
- limpiar la entrada para mostrar "2025" correctamente

## Testing
- `node --check script.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852a73768248331bca53b1b221c2f15