### PR TITLE
Fix lineup data structure

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,19 +35,22 @@ updateCountdown();
 const posterPath = 'cartel diseño instagram  final.png';
 const bands = [
     {
-        name: `<img src="${posterPath}" alt="Cartel pequeño" class="small-poster">`,
-        image: "https://via.placeholder.com/300x300",
-        description: "2025"
+        name: 'Cartel',
+        alt: 'Cartel',
+        image: posterPath,
+        description: '2025'
     },
     {
-        name: `<img src="${posterPath}" alt="Cartel pequeño" class="small-poster">`,
-        image: "https://via.placeholder.com/300x300",
-        description: "2025"
+        name: 'TBD',
+        alt: 'Cartel',
+        image: posterPath,
+        description: '2025'
     },
     {
-        name: `<img src="${posterPath}" alt="Cartel pequeño" class="small-poster">`,
-        image: "https://via.placeholder.com/300x300",
-        description: "2025"
+        name: 'TBD',
+        alt: 'Banda por anunciar',
+        image: 'https://via.placeholder.com/300x300',
+        description: '2025'
     }
 ];
 
@@ -59,7 +62,7 @@ function createBandCards() {
         const bandCard = document.createElement('div');
         bandCard.className = 'band-card';
         bandCard.innerHTML = `
-            <img src="${band.image}" alt="${band.name}">
+            <img src="${band.image}" alt="${band.alt}">
             <h3>${band.name}</h3>
             <p>${band.description}</p>
         `;

--- a/style.css
+++ b/style.css
@@ -136,12 +136,6 @@ body {
     gap: 2rem;
 }
 
-/* Small poster used in lineup placeholders */
-.small-poster {
-    width: 80px;
-    height: auto;
-}
-
 /* Info Section */
 .info {
     padding: 5rem 10%;


### PR DESCRIPTION
## Summary
- refactor bands data to store text and alt attributes
- remove unused small poster styles
- update card creation to use alt text

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/terrassa/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6852d1964aec8331ba70d148cbbd2259